### PR TITLE
fix iOS/mobile perf issue during scroll

### DIFF
--- a/app/routes/application.js
+++ b/app/routes/application.js
@@ -1,8 +1,6 @@
 import Ember from 'ember';
 import getData from '../lib/get-data';
 
-var TIMEOUT = 0;
-
 export default Ember.Route.extend({
   model: function() {
     return {
@@ -43,6 +41,6 @@ export default Ember.Route.extend({
 
     Ember.set(model, 'databaseArray', databaseArray);
 
-    setTimeout(this.loadSamples.bind(this), TIMEOUT);
+    requestAnimationFrame(Ember.run.bind(this, this.loadSamples));
   }
 });


### PR DESCRIPTION
1. iOS throttles setTimeouts during scroll, these then pile up
2. bare setTimeout spews an addition setTimeout via auto-run (suboptimal, and makes 1. worse)

thanks to @jayphelps for bringing the scroll jank on iOS to my attention.

Now during scroll, the updates continue rather then pause/slow down.
